### PR TITLE
Added initial e2e testing setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules

--- a/cypress.json
+++ b/cypress.json
@@ -1,0 +1,5 @@
+{
+    "env": {
+        "baseUrl": "localhost:5000"
+    }
+}

--- a/cypress/fixtures/example.json
+++ b/cypress/fixtures/example.json
@@ -1,0 +1,5 @@
+{
+  "name": "Using fixtures to represent data",
+  "email": "hello@cypress.io",
+  "body": "Fixtures are a great way to mock data for responses to routes"
+}

--- a/cypress/integration/game/game_window.spec.js
+++ b/cypress/integration/game/game_window.spec.js
@@ -1,0 +1,30 @@
+describe('Game window page', () => {
+    beforeEach(() => {
+        cy.visit(Cypress.env('baseUrl'));
+        cy.get('body').trigger('keydown', { keyCode: 13 });
+    });
+  
+    it('Displays the main character', () => {
+        cy.get(".pac-man")
+            .should("be.visible");
+    });
+
+    it('Displays the 4 enemies', () => {
+        cy.get(".blinky")
+          .should("be.visible");
+
+        cy.get(".stinky")
+          .should("be.visible");
+
+        cy.get(".inky")
+          .should("be.visible");
+
+        cy.get(".clyde")
+          .should("be.visible");
+    });
+
+    after(() => {
+      cy.visit(Cypress.env('baseUrl'));
+    });
+    
+  });

--- a/cypress/integration/game/start_window.spec.js
+++ b/cypress/integration/game/start_window.spec.js
@@ -1,0 +1,30 @@
+describe('Start window page', () => {
+    beforeEach(() => {
+        cy.visit(Cypress.env('baseUrl'));
+    });
+  
+    it('Displays the right title for the game', () => {
+        cy.get("h1")
+          .should('be.visible')
+          .should('contain', 'PACMAN');
+    });
+    it('Displays the action needed to enter the game', () => {
+        cy.get("#start-msg")
+          .should('be.visible')
+          .should('contain', 'Press ENTER to start');
+    });
+    it('Should have a background color black', () => {
+        cy.get("#start-screen")
+          .should('have.css', 'background-color', 'rgb(0, 0, 0)');
+    });
+    it('Should rediret to the game', () => {
+        cy.get('body').trigger('keydown', { keyCode: 13 });
+        cy.get("#start-screen")
+          .should('have.css', 'display', 'none');
+    });
+
+    after(() => {
+      cy.visit(Cypress.env('baseUrl'));
+    });
+
+  });

--- a/cypress/plugins/index.js
+++ b/cypress/plugins/index.js
@@ -1,0 +1,21 @@
+/// <reference types="cypress" />
+// ***********************************************************
+// This example plugins/index.js can be used to load plugins
+//
+// You can change the location of this file or turn off loading
+// the plugins file with the 'pluginsFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/plugins-guide
+// ***********************************************************
+
+// This function is called when a project is opened or re-opened (e.g. due to
+// the project's config changing)
+
+/**
+ * @type {Cypress.PluginConfig}
+ */
+module.exports = (on, config) => {
+  // `on` is used to hook into various events Cypress emits
+  // `config` is the resolved Cypress config
+}

--- a/cypress/support/commands.js
+++ b/cypress/support/commands.js
@@ -1,0 +1,25 @@
+// ***********************************************
+// This example commands.js shows you how to
+// create various custom commands and overwrite
+// existing commands.
+//
+// For more comprehensive examples of custom
+// commands please read more here:
+// https://on.cypress.io/custom-commands
+// ***********************************************
+//
+//
+// -- This is a parent command --
+// Cypress.Commands.add("login", (email, password) => { ... })
+//
+//
+// -- This is a child command --
+// Cypress.Commands.add("drag", { prevSubject: 'element'}, (subject, options) => { ... })
+//
+//
+// -- This is a dual command --
+// Cypress.Commands.add("dismiss", { prevSubject: 'optional'}, (subject, options) => { ... })
+//
+//
+// -- This will overwrite an existing command --
+// Cypress.Commands.overwrite("visit", (originalFn, url, options) => { ... })

--- a/cypress/support/index.js
+++ b/cypress/support/index.js
@@ -1,0 +1,20 @@
+// ***********************************************************
+// This example support/index.js is processed and
+// loaded automatically before your test files.
+//
+// This is a great place to put global configuration and
+// behavior that modifies Cypress.
+//
+// You can change the location of this file or turn off
+// automatically serving support files with the
+// 'supportFile' configuration option.
+//
+// You can read more here:
+// https://on.cypress.io/configuration
+// ***********************************************************
+
+// Import commands.js using ES2015 syntax:
+import './commands'
+
+// Alternatively you can use CommonJS syntax:
+// require('./commands')

--- a/package.json
+++ b/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "pacman-game",
+  "version": "1.0.0",
+  "description": "PacmanJs is a Javascript, HTML and CSS based game that enable you to play with the most charismatic 80's character ever created.",
+  "main": "app.js",
+  "scripts": {
+    "e2e": "cypress open"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/RishabhDevbanshi/Pacman-Game.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/RishabhDevbanshi/Pacman-Game/issues"
+  },
+  "homepage": "https://github.com/RishabhDevbanshi/Pacman-Game#readme",
+  "devDependencies": {
+    "cypress": "^5.3.0"
+  }
+}


### PR DESCRIPTION
This is the initial part of the e2e automation script.  #102 

I added two main scripts one for the main window and other one for the main game with their respective tests. 
I also added in the package.json a new  script with the name e2e that will run the cypress instance. 

There are more things in detail that I could create in the wiki   ( i.e what you need to install to run cypress )
https://docs.cypress.io/guides/getting-started/installing-cypress.html#System-requirements

If you want to run the static index.html and serve it in the localhost then one option is this npm module

https://www.npmjs.com/package/serve.

Let me know your thoughts!
Thanks! 




